### PR TITLE
Update resource.cpp

### DIFF
--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -76,10 +76,10 @@ static const char *kMulticastAddrAllRouters = "ff03::2";
 static const uint8_t kAllTlvTypes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 19};
 
 // Timeout (in Microseconds) for deleting outdated diagnostics
-static const uint32_t kDiagResetTimeout = 3000000;
+static const uint32_t kDiagResetTimeout = 120000000;
 
 // Timeout (in Microseconds) for collecting diagnostics
-static const uint32_t kDiagCollectTimeout = 2000000;
+static const uint32_t kDiagCollectTimeout = 10000000;
 
 static std::string GetHttpStatus(HttpStatusCode aErrorCode)
 {


### PR DESCRIPTION
Updated REST diagnostics timeout sttings to more reasonable values. Originally the `diagnostics` REST call would time out after 2 seconds, and stale data would be purge after 3 seconds. This change updates the timeout to 10 seconds and the stale data purge to 2 minutes. This at least provides for a workable set of defaults that work with the Web UI Topology page. Ideally the Topology page would refresh peridically in the background at a frequency less than the stale data timeout.